### PR TITLE
feat: access Request object from resource loader

### DIFF
--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -2,8 +2,8 @@ const { debug } = require('../log')('resource')
 
 function factory ({ loader }) {
   return async (req, res, next) => {
-    const classResources = await loader.forClassOperation(req.hydra.term)
-    const propertyObjectResources = await loader.forPropertyOperation(req.hydra.term)
+    const classResources = await loader.forClassOperation(req.hydra.term, req)
+    const propertyObjectResources = await loader.forPropertyOperation(req.hydra.term, req)
 
     res.locals.hydra.resources = [
       ...classResources,


### PR DESCRIPTION
I would like to be able to access the express request object from resource loader. 

This will allow me to access various request-context objects such as a preconfigured RDF loader or logger